### PR TITLE
Replace newlines in payload with whitespaces

### DIFF
--- a/feedback-hub-searchmetrics-lib/src/main/java/com/coremedia/blueprint/searchmetrics/SearchmetricsConnector.java
+++ b/feedback-hub-searchmetrics-lib/src/main/java/com/coremedia/blueprint/searchmetrics/SearchmetricsConnector.java
@@ -51,7 +51,7 @@ public class SearchmetricsConnector {
 
   @NonNull
   private HttpEntity<String> buildRequestEntity(@NonNull SearchmetricsSettings settings, @Nullable String payload) {
-    return new HttpEntity<>(payload.replaceAll("\n", ""), buildHttpHeaders(settings));
+    return new HttpEntity<>(payload.replaceAll("\n", " "), buildHttpHeaders(settings));
   }
 
   @NonNull


### PR DESCRIPTION
In order to not confuse the SearchMetrics text analysis, we should replace newlines in our payload to SearchMetrics with whitespaces instead of empty strings.